### PR TITLE
- Added support for _removeXPaths config key, which allows removing s…

### DIFF
--- a/OpenScraping.Tests/OpenScraping.Tests.csproj
+++ b/OpenScraping.Tests/OpenScraping.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
   </ItemGroup>
@@ -30,6 +30,15 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="TestData\quora.com.withwiki.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TestData\article_with_comments_div.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TestData\article_with_comments_div.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TestData\stackexchange_plural_singular_rules.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="TestData\stackexchange.com.json">

--- a/OpenScraping.Tests/TestData/article_with_comments_div.html
+++ b/OpenScraping.Tests/TestData/article_with_comments_div.html
@@ -1,0 +1,22 @@
+﻿<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title>Page title</title>
+</head>
+<body>
+    <h1>  Article  title    </h1>
+    <div id="primary">
+        <script>alert('test');</script>
+
+        <p>Para1     content</p>
+        <p>Para2   content</p>
+
+        <div id="comments">
+            <p>Comment1</p>
+            <p>Comment2</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/OpenScraping.Tests/TestData/article_with_comments_div.json
+++ b/OpenScraping.Tests/TestData/article_with_comments_div.json
@@ -1,0 +1,20 @@
+﻿{
+  "_removeTags": [
+    "script"
+  ],
+  "title": {
+    "_xpath": "//h1",
+    "_transformations": [
+      "TrimTransformation"
+    ]
+  },
+  "body": {
+    "_removeXPaths": [
+      "./div[@id='comments']"
+    ],
+    "_xpath": "//div[@id='primary']",
+    "_transformations": [
+      "RemoveExtraWhitespaceTransformation"
+    ]
+  }
+}

--- a/OpenScraping.Tests/TestData/stackexchange_plural_singular_rules.json
+++ b/OpenScraping.Tests/TestData/stackexchange_plural_singular_rules.json
@@ -1,0 +1,60 @@
+﻿{
+    "_urlPattern": [
+        "^https?:\/\/.+\\.stackexchange\\.com\/questions\/[0-9]+\/.+$",
+        "^https?:\/\/stackoverflow\\.com\/questions\/[0-9]+\/.+$",
+        "^https?:\/\/serverfault\\.com\/questions\/[0-9]+\/.+$",
+        "^https?:\/\/superuser\\.com\/questions\/[0-9]+\/.+$",
+        "^https?:\/\/askubuntu\\.com\/questions\/[0-9]+\/.+$"
+    ],
+    "_removeTag": [
+        "script",
+        "style",
+        "#comment"
+    ],
+    "question": {
+        "_xpaths": "(//*[@itemtype='http://schema.org/Question'])[1]",
+        "title": "(.//*[@itemprop='name'])[1]",
+        "content": {
+            "_xpath": "(.//*[@itemprop='text'])[1]",
+            "_transformation": "RemoveExtraWhitespaceTransformation"
+        },
+        "hints": ".//div[contains(@class, 'post-taglist')]/a",
+        "votes": {
+            "_xpaths": "(.//*[@itemprop='upvoteCount'])[1]",
+            "_transformation": "CastToIntegerTransformation"
+        }
+    },
+    "bestAnswer": {
+        "_xpaths": "(//*[@itemtype='http://schema.org/Question'])[1]//*[@itemtype='http://schema.org/Answer' and @itemprop='acceptedAnswer'][1]",
+        "content": "(.//*[@itemprop='text'])[1]",
+        "votes": {
+            "_xpaths": "(.//*[@itemprop='upvoteCount'])[1]",
+            "_transformation": "CastToIntegerTransformation"
+        },
+        "lists": {
+            "_xpaths": ".//ol | .//ul",
+            "_forceArray": true,
+            "textAboveLength": {
+                "_xpaths": ".",
+                "_transformation": [
+                    {
+                        "_type": "TotalTextLengthAboveListTransformation",
+                        "_comment": "Please note: the context of _startingXPath is the _xpath for bestAnswer above, not of lists above",
+                        "_startingXPath": "(.//*[@itemprop='text'])[1]"
+                    }
+                ]
+            },
+            "title": {
+                "_xpaths": ".",
+                "_transformation": [
+                    {
+                        "_type": "ListTitleTransformation",
+                        "_maxStepsUpward": 3,
+                        "_maxTitleLength": 250
+                    }
+                ]
+            },
+            "items": "./li"
+        }
+    }
+}

--- a/OpenScraping/Config/ConfigSection.cs
+++ b/OpenScraping/Config/ConfigSection.cs
@@ -15,6 +15,7 @@ namespace OpenScraping.Config
             this.ConfigName = string.Empty;
             this.RemoveTags = new HashSet<string>();
             this.UrlPatterns = new List<string>();
+            this.RemoveXPathRules = new HashSet<string>();
             this.XPathRules = new List<string>();
             this.Transformations = new List<TransformationConfig>();
             this.Children = new Dictionary<string, ConfigSection>();
@@ -29,6 +30,9 @@ namespace OpenScraping.Config
 
         // List of descendent tags to remove before extracting any data from this node
         public HashSet<string> RemoveTags { get; set; }
+
+        // List of XPath rules to apply for deleting descendant nodes before extracting any data from this node
+        public HashSet<string> RemoveXPathRules { get; set; }
 
         // The list of XPaths to use to find these kinds of items in the HTML
         public List<string> XPathRules { get; set; }

--- a/OpenScraping/OpenScraping.csproj
+++ b/OpenScraping/OpenScraping.csproj
@@ -8,14 +8,16 @@
     <PackageProjectUrl>https://github.com/Microsoft/openscraping-lib-csharp</PackageProjectUrl>
     <RepositoryType>https://github.com/Microsoft/openscraping-lib-csharp</RepositoryType>
     <PackageTags>html extraction scraping scraper parser parsing open scraping openscraping</PackageTags>
-    <PackageReleaseNotes>.NET Standard 2.0 support</PackageReleaseNotes>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <FileVersion>1.1.0.0</FileVersion>
+    <PackageReleaseNotes>- Added support for _removeXPaths config key, which allows removing some child nodes based on xPath rules BEFORE we process the main parent node. Useful for example when extracting a news article that contains divs that we want to remove BEFORE we extract the body of an article.
+- Updated some dependencies like HtmlAgilityPack to the latest stable version.
+- Simplified reading configs and added support for specifying some config keys as either singular or plural, and setting their values to either a single value or an array.</PackageReleaseNotes>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.2.0.0</FileVersion>
     <PackageIconUrl>https://github.com/Microsoft/openscraping-lib-csharp/blob/master/logo.png?raw=true</PackageIconUrl>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.8.7" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.8.10" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 </Project>

--- a/OpenScraping/StructuredDataExtractor.cs
+++ b/OpenScraping/StructuredDataExtractor.cs
@@ -134,6 +134,8 @@ namespace OpenScraping
 
                         foreach (HtmlNodeNavigator node in nodes)
                         {
+                            this.RemoveXPaths(config, node.CurrentNode);
+
                             if (config.Children != null && config.Children.Count > 0)
                             {
                                 var container = new JObject();
@@ -186,6 +188,23 @@ namespace OpenScraping
                         .Where(n => config.RemoveTags.Contains(n.Name.ToLowerInvariant()))
                         .ToList()
                         .ForEach(n => n.Remove());
+            }
+        }
+
+        private void RemoveXPaths(ConfigSection config, HtmlAgilityPack.HtmlNode parentNode)
+        {
+            if (parentNode != null && config != null && config.RemoveXPathRules != null && config.RemoveXPathRules.Count > 0)
+            {
+                foreach (var removeXPathRule in config.RemoveXPathRules)
+                {
+                    var navigator = parentNode.CreateNavigator();
+                    var nodes = navigator.Select(removeXPathRule);
+
+                    foreach (HtmlNodeNavigator node in nodes)
+                    {
+                        node.CurrentNode.Remove();
+                    }
+                }
             }
         }
 

--- a/nuget/README.md
+++ b/nuget/README.md
@@ -3,6 +3,7 @@ Reference - [How to Create a NuGet Package with Cross Platform Tools](https://gi
 Reference - [dotnet nuget push](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-push)
 
 To generate the Nuget package:
+- Right click on OpenScraping project > Properties > Package. Increment Package version, Assembly version, Assembly file version
 - Go to the root folder openscraping-lib-csharp
 - dotnet pack --configuration release
 - dotnet nuget push /path/to/OpenScraping.X.X.X.nupkg -s https://www.nuget.org/api/v2/package -k <API_KEY_HERE>


### PR DESCRIPTION
…ome child nodes based on xPath rules BEFORE we process the main parent node. Useful for example when extracting a news article that contains divs that we want to remove BEFORE we extract the body of an article.

- Updated some dependencies like HtmlAgilityPack to the latest stable version.
- Simplified reading configs and added support for specifying some config keys as either singular or plural, and setting their values to either a single value or an array.